### PR TITLE
🧹 Refactor code

### DIFF
--- a/Assets/Runtime/Scripts/LifetimeScopes/TitleLifetimeScope.cs
+++ b/Assets/Runtime/Scripts/LifetimeScopes/TitleLifetimeScope.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using Monry.WhackMole.Presenters;
-using Monry.WhackMole.Views.Title;
 using VContainer;
 using VContainer.Unity;
 using VitalRouter.VContainer;
@@ -26,7 +25,6 @@ namespace Monry.WhackMole.LifetimeScopes
             {
                 routingBuilder.Map<TitlePresenter>();
             });
-            builder.Register<CounterButton.Processor>(Lifetime.Singleton);
         }
     }
 }

--- a/Assets/Runtime/Scripts/LifetimeScopes/TitleLifetimeScope.cs
+++ b/Assets/Runtime/Scripts/LifetimeScopes/TitleLifetimeScope.cs
@@ -6,25 +6,27 @@ using VContainer.Unity;
 using VitalRouter.VContainer;
 using ZLogger.Unity;
 
-namespace Monry.WhackMole.LifetimeScopes;
-
-public class TitleLifetimeScope : LifetimeScope
+// ReSharper disable once ArrangeNamespaceBody
+namespace Monry.WhackMole.LifetimeScopes
 {
-    protected override void Configure(IContainerBuilder builder)
+    public class TitleLifetimeScope : LifetimeScope
     {
-        builder.Register<ILoggerFactory>(
-            _ =>
-                LoggerFactory.Create(
-                    logging =>
-                    {
-                        logging.AddZLoggerUnityDebug();
-                    }),
-            Lifetime.Singleton
-        );
-        builder.RegisterVitalRouter(routingBuilder =>
+        protected override void Configure(IContainerBuilder builder)
         {
-            routingBuilder.Map<TitlePresenter>();
-        });
-        builder.Register<CounterButton.Processor>(Lifetime.Singleton);
+            builder.Register<ILoggerFactory>(
+                _ =>
+                    LoggerFactory.Create(
+                        logging =>
+                        {
+                            logging.AddZLoggerUnityDebug();
+                        }),
+                Lifetime.Singleton
+            );
+            builder.RegisterVitalRouter(routingBuilder =>
+            {
+                routingBuilder.Map<TitlePresenter>();
+            });
+            builder.Register<CounterButton.Processor>(Lifetime.Singleton);
+        }
     }
 }

--- a/Assets/Runtime/Scripts/Views/Title/CounterButton.cs
+++ b/Assets/Runtime/Scripts/Views/Title/CounterButton.cs
@@ -7,28 +7,30 @@ using UnityEngine.UI;
 using VContainer;
 using VitalRouter;
 
-namespace Monry.WhackMole.Views.Title;
-
-public class CounterButton : MonoBehaviour
+// ReSharper disable once ArrangeNamespaceBody
+namespace Monry.WhackMole.Views.Title
 {
-    [SerializeField] private Button _button = default!;
-    [Inject] private Processor _processor = default!;
-    private int _counter = 0;
-
-    private void Start()
+    public class CounterButton : MonoBehaviour
     {
-        _button.OnClickAsObservable()
-            .BindCommand(_processor, () => new ButtonClickedCommand(++_counter))
-            .AddTo(this);
-    }
+        [SerializeField] private Button _button = default!;
+        [Inject] private Processor _processor = default!;
+        private int _counter = 0;
 
-    public class Processor : ICommandPublishable<ButtonClickedCommand>
-    {
-        public ICommandPublisher CommandPublisher { get; }
-
-        public Processor(ICommandPublisher commandPublisher)
+        private void Start()
         {
-            CommandPublisher = commandPublisher;
+            _button.OnClickAsObservable()
+                .BindCommand(_processor, () => new ButtonClickedCommand(++_counter))
+                .AddTo(this);
+        }
+
+        public class Processor : ICommandPublishable<ButtonClickedCommand>
+        {
+            public ICommandPublisher CommandPublisher { get; }
+
+            public Processor(ICommandPublisher commandPublisher)
+            {
+                CommandPublisher = commandPublisher;
+            }
         }
     }
 }

--- a/Assets/Runtime/Scripts/Views/Title/CounterButton.cs
+++ b/Assets/Runtime/Scripts/Views/Title/CounterButton.cs
@@ -10,27 +10,17 @@ using VitalRouter;
 // ReSharper disable once ArrangeNamespaceBody
 namespace Monry.WhackMole.Views.Title
 {
-    public class CounterButton : MonoBehaviour
+    public class CounterButton : MonoBehaviour, ICommandPublishable<ButtonClickedCommand>
     {
         [SerializeField] private Button _button = default!;
-        [Inject] private Processor _processor = default!;
+        [Inject] public ICommandPublisher CommandPublisher { get; set; } = default!;
         private int _counter = 0;
 
         private void Start()
         {
             _button.OnClickAsObservable()
-                .BindCommand(_processor, () => new ButtonClickedCommand(++_counter))
+                .BindCommand(this, () => new ButtonClickedCommand(++_counter))
                 .AddTo(this);
-        }
-
-        public class Processor : ICommandPublishable<ButtonClickedCommand>
-        {
-            public ICommandPublisher CommandPublisher { get; }
-
-            public Processor(ICommandPublisher commandPublisher)
-            {
-                CommandPublisher = commandPublisher;
-            }
         }
     }
 }


### PR DESCRIPTION
- 不要なインナークラスを削除
- file-scoped namespace は危険な場合があるので、Unity 的に Serializable な型は block-scoped にする